### PR TITLE
Misc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ ___
 * Bundled for Windows using Launch4j 3.12 and Inno Setup 6.0.4
 
 ___
-According to CLOC, 1.1.0's metrics:
+According to CLOC, 1.1.1's metrics:
 * 96 .java files
-* 3575 blank lines
-* 2368 comment lines
-* 17260 code lines
+* 3581 blank lines
+* 2367 comment lines
+* 17276 code lines

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ___
   - Giving the player Damage Resistance
   - Average probability to break a Light Armor plate
   - Slowing enemies
-  - Inflicing Fear on enemies
+  - Inflicting Fear on enemies
   - Stunning enemies
   - Freezing enemies
 - Average time required to Ignite or Freeze an enemy (if the Weapon is able to do either Heat or Cold with its attacks)
@@ -59,7 +59,7 @@ After you finish installing it on your local computer, there are a wide variety 
   - Any Mod or Overclock that you already have selected will be guaranteed to be in the final build
   - Right-click on a Mod or Overclock to exclude it from being part of the calculations
 - By default, it starts out by modeling its metrics based on (Hazard 4/4 Player) Difficulty Scaling, but you can customize it to any Hazard level and any number of Players (excluding Deep Dive and Elite Deep Dive scaling)
-- Export the data for every comination of Mods and Overclocks for every weapon! 
+- Export the data for every combination of Mods and Overclocks for every weapon! 
   - Export a CSV file for only the selected model
   - Export the CSV files for all models simultaneously
   - Export every combination of every model in one giant MySQL table

--- a/src/modelPieces/DwarfInformation.java
+++ b/src/modelPieces/DwarfInformation.java
@@ -16,5 +16,5 @@ public class DwarfInformation {
 	// These are measured in m/sec
 	public static double walkSpeed = 3.0;
 	public static double runSpeed = 4.35;
-	public static double jumpVelocityAdded = 5.0;
+	public static double jumpVelocityAdded = 5.5;
 }

--- a/src/modelPieces/EnemyInformation.java
+++ b/src/modelPieces/EnemyInformation.java
@@ -518,6 +518,7 @@ public class EnemyInformation {
 					burnDuration = (heatPerShot - alias.getDouseTemp()) / alias.getCoolingRate();
 				}
 				else {
+					// TODO: Lunari noticed a bug where Bullet Hell + Hot Bullets makes this "ignite" a swarmer in one bullet due to the floor() function, whereas it should need 2.
 					// This is technically an approximation and not precisely how it works in-game, but it's close enough for what I need.
 					numShotsToProcBurn = Math.floor((alias.getIgniteTemp() * RoF) / (heatPerShot * RoF - alias.getCoolingRate()));
 					burnDuration = (alias.getIgniteTemp() - alias.getDouseTemp()) / alias.getCoolingRate();
@@ -682,10 +683,10 @@ public class EnemyInformation {
 					heavyArmorHP = alias.getArmorBaseHealth() * normalResistance;
 					
 					if (embeddedDetonators) {
-						numShotsToBreakArmor = heavyArmorHP / (rawDirectDamage * armorBreaking);
+						numShotsToBreakArmor = Math.ceil(heavyArmorHP / (rawDirectDamage * armorBreaking));
 					}
 					else {
-						numShotsToBreakArmor = heavyArmorHP / ((rawDirectDamage + rawAreaDamage) * armorBreaking);
+						numShotsToBreakArmor = Math.ceil(heavyArmorHP / ((rawDirectDamage + rawAreaDamage) * armorBreaking));
 					}
 				}
 				else {

--- a/src/modelPieces/EnemyInformation.java
+++ b/src/modelPieces/EnemyInformation.java
@@ -518,9 +518,16 @@ public class EnemyInformation {
 					burnDuration = (heatPerShot - alias.getDouseTemp()) / alias.getCoolingRate();
 				}
 				else {
-					// TODO: Lunari noticed a bug where Bullet Hell + Hot Bullets makes this "ignite" a swarmer in one bullet due to the floor() function, whereas it should need 2.
-					// This is technically an approximation and not precisely how it works in-game, but it's close enough for what I need.
-					numShotsToProcBurn = Math.floor((alias.getIgniteTemp() * RoF) / (heatPerShot * RoF - alias.getCoolingRate()));
+					// First, check if the weapon can fully ignite the enemy in less than one second (the default interval for CoolingRate, only Bulk Detonators use 0.25)
+					if (heatPerShot * Math.floor(0.99 * RoF) >= alias.getIgniteTemp()) {
+						numShotsToProcBurn = Math.ceil(alias.getIgniteTemp() / heatPerShot);
+					}
+					// If not, then this has to account for the Cooling Rate increasing the number of shots required.
+					else {
+						// This is technically an approximation and not precisely how it works in-game, but it's close enough for what I need.
+						numShotsToProcBurn = Math.floor((alias.getIgniteTemp() * RoF) / (heatPerShot * RoF - alias.getCoolingRate()));
+					}
+					
 					burnDuration = (alias.getIgniteTemp() - alias.getDouseTemp()) / alias.getCoolingRate();
 				}
 			}

--- a/src/weapons/engineer/BreachCutter.java
+++ b/src/weapons/engineer/BreachCutter.java
@@ -119,7 +119,7 @@ public class BreachCutter extends Weapon {
 				+ "the line to change direction and move back towards the gun. In exchange, -6 Max Ammo", overclockIcons.returnToSender, 3);
 		overclocks[4] = new Overclock(Overclock.classification.balanced, "High Voltage Crossover", "100% chance to electrocute enemies, which deals an average of " + MathUtils.round(4.0 * DoTInformation.Electro_TicksPerSec, GuiConstants.numDecimalPlaces) + " Electric Damage per "
 				+ "Second for 4 seconds. In exchange, x0.67 Magazine Size.", overclockIcons.electricity, 4);
-		overclocks[5] = new Overclock(Overclock.classification.unstable, "Spinning Death", "Instead of flying in a straight line, the projectile now rotates 2 times per second about the Yaw axis. Additionally: x0.15 Projectile Velocity, x0 Impact Damage, "
+		overclocks[5] = new Overclock(Overclock.classification.unstable, "Spinning Death", "Instead of flying in a straight line, the projectile now rotates 2 times per second about the Yaw axis. Additionally: x0.05 Projectile Velocity, x0 Impact Damage, "
 				+ "x2.5 Projectile Lifetime, x0.24 Damage per Tick, +1.5m Plasma Beam Width, x0.5 Max Ammo, and x0.33 Magazine Size", overclockIcons.special, 5);
 		overclocks[6] = new Overclock(Overclock.classification.unstable, "Inferno", "The first time the beam hits an enemy, it inflicts 75 Heat and applies a DoT that does 7 Fire Damage and 7 Heat at a rate of 2 ticks/sec for 5 seconds (does 11 ticks total). "
 				+ "Additionally, it converts 90% of the Damage per Tick from Electric element to Fire element and adds the amount converted as Heat per tick. In exchange: -3.5 Damage per Tick and x0.25 Armor Breaking", overclockIcons.heatDamage, 6);
@@ -155,8 +155,7 @@ public class BreachCutter extends Weapon {
 		
 		// Spinning Death makes it move a lot slower
 		if (selectedOverclock == 5) {
-			// TODO: Dagadegatto says that this is still supposed to be 0.05 (0.5 m/sec) but U34 bugged it out and now it's going 1.5 m/sec and they haven't fixed it as of U34
-			toReturn *= 0.15;
+			toReturn *= 0.05;
 		}
 		
 		return toReturn;

--- a/src/weapons/engineer/GrenadeLauncher.java
+++ b/src/weapons/engineer/GrenadeLauncher.java
@@ -92,10 +92,11 @@ public class GrenadeLauncher extends Weapon {
 		tier4[1] = new Mod("Nails + Tape", "+1m AoE Radius", modIcons.aoeRadius, 4, 1);
 		tier4[2] = new Mod("Concussive Blast", "Stuns creatures within the blast radius for 3 seconds", modIcons.stun, 4, 2);
 		
-		tier5 = new Mod[2];
+		tier5 = new Mod[3];
 		tier5[0] = new Mod("Proximity Trigger", "After 0.2 seconds of arming time, any grenade that passes within 2m of an enemy will detonate after a 0.1 second delay. After being armed, grenades will emit a green light. "
 				+ "Grenades no longer explode upon impacting terrain, but instead automatically self-detonate 3.3 seconds after being fired or when they stop moving. Additionally, x1.1 AoE Radius.", modIcons.special, 5, 0);
 		tier5[1] = new Mod("Spiky Grenade", "+60 Direct Damage to any target directly impacted by a grenade.", modIcons.directDamage, 5, 1);
+		tier5[2] = new Mod("Disabled Inertia Inhibitor", "Changes the PGL to add the player's current velocity to the grenades being fired, instead of using a flat velocity for every grenade. ", modIcons.projectileVelocity, 5, 2, false);
 		
 		overclocks = new Overclock[6];
 		overclocks[0] = new Overclock(Overclock.classification.clean, "Clean Sweep", "+10 Area Damage, +0.5m AoE Radius", overclockIcons.aoeRadius, 0);

--- a/src/weapons/gunner/BurstPistol.java
+++ b/src/weapons/gunner/BurstPistol.java
@@ -51,7 +51,7 @@ public class BurstPistol extends Weapon {
 		// Base stats, before mods or overclocks alter them:
 		directDamage = 21;
 		burstSize = 3;
-		delayBetweenBulletsDuringBurst = 0.05;
+		delayBetweenBulletsDuringBurst = 0.08;
 		carriedAmmo = 120;
 		magazineSize = 24;
 		rateOfFire = 3.0;

--- a/src/weapons/gunner/Minigun.java
+++ b/src/weapons/gunner/Minigun.java
@@ -470,7 +470,7 @@ public class Minigun extends Weapon {
 			generalAccuracy = 1.0;
 		}
 		
-		// Special case: the overclock Bullet Hell gives every bullet a 50% chance to ricochet into nearby enemies after impacting terrain or an enemy
+		// Special case: the overclock Bullet Hell gives every bullet a 75% chance to ricochet into nearby enemies after impacting terrain or an enemy
 		if (selectedOverclock == 5 && accuracy) {
 			// Never let it be above 1.0 probability to hit a target.
 			generalAccuracy = Math.min(generalAccuracy + 0.75, 1.0);

--- a/src/weapons/gunner/Minigun.java
+++ b/src/weapons/gunner/Minigun.java
@@ -398,8 +398,8 @@ public class Minigun extends Weapon {
 		return Math.floor(calculateFiringPeriod() * getRateOfFire() / 2.0);
 	}
 	private double calculateCooldownPeriod() {
-		// This equation took a while to figure out, and it's still just an approximation. A very close approximation, but an approximation nonetheless.
-		return getCoolingDelay() + 9.5 / getCoolingRate() + getCoolingRate() / 9;
+		// MikeGSG told me that my approximation was wrong. It's just a simple linear cooling rate. 6 Heat at 1.5 Cooling Rate would take 4 seconds to cool off, after the CoolingDelay.
+		return getCoolingDelay() + maxHeat / getCoolingRate();
 	}
 	
 	@Override
@@ -487,6 +487,8 @@ public class Minigun extends Weapon {
 				GetAll GatlingHotShellsBonusUpgrade TemperatureRequired
 			
 			Unless Burning Hell is equipped, that's functionally the time before bullets have Heat Damage added to them.
+			
+			Additionally, from my own testing, it seems that the Heat Meter changes from Green to Yellow at y=30 and Yellow to Red at y=60. That's x=1.78 and x=3.88, respectively.
 		*/
 		double timeBeforeHotBullets = secondsBeforeHotBullets;
 		


### PR DESCRIPTION
- Fixed Minigun's Cooling Period, per Dagadegatto's explanation
- (unused value) Updated Dwarf jump velocity based on gamefile
- Reverted Breach Cutter OC "Spinning Death" Movement multiplier back to x0.05; seems GSG fixed it without mentioning in patch notes
- Added new PGL T5.C
- Fixed Breakpoints bug where Brundle's Armor could be bypassed without AB
- Fixed Breakpoints bug where Minigun T5.C Hot Bullets could ignite Swarmers in one bullet due to "lazy math" approach that had been used
- Updated BRT burst from 0.05 between bullets (measured by counting frames from 60 fps video) to 0.08, based on console command. Technically a bugfix?
- Lunari requested that M1k Hipfired gets the Customizable RoF too, so I did a quick implementation of that.